### PR TITLE
fix TypeError on undefined options

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -2,7 +2,7 @@ require('express-hijackresponse');
 require('bufferjs');
 
 module.exports = function (options) {
-    if (typeof options.options === 'undefined') {
+    if (!options || typeof options.options === 'undefined') {
         // Default options for autoprefixer. See https://github.com/ai/autoprefixer#browsers
         options.options = [
             '> 1%',


### PR DESCRIPTION
usage:

```
app.use(require('express-autoprefixer')())
```

error:

```
    if (typeof options.options === 'undefined') {
                      ^
TypeError: Cannot read property 'options' of undefined
```
