### PR TITLE
Fixed browser version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ var express = require('express'),
     root = '/path/to/my/static/files';
 
 express.createServer()
-    .use(autoprefixer({ browsers: 'last two versions', cascade: false }))
+    .use(autoprefixer({ browsers: 'last 2 versions', cascade: false }))
     .use(express.static(root))
     .listen(1337);
 ```


### PR DESCRIPTION
The browser version string crashed my app. Using "2" instead of "two" fixed it.