### PR TITLE
use postcss with autoprefixer as plugin

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -1,5 +1,6 @@
 var interceptor  = require('express-interceptor');
 var autoprefixer = require('autoprefixer');
+var postcss = require('postcss');
 
 module.exports = function () {
     var args = Array.prototype.slice.call(arguments);
@@ -35,16 +36,25 @@ module.exports = function () {
                     if (!body.length) {
                         send(res.statusCode);
                     }
-                    body = autoprefixer.apply(null, args).process(body).css;
 
-                    res.setHeader('Content-Type', 'text/css');
-                    var upstreamETag = res.getHeader('ETag');
-                    if (upstreamETag) {
-                        res.setHeader('ETag', upstreamETag.replace(/"$/, '-autoprefixer"'));
-                    }
-                    res.setHeader('Content-Length', Buffer.byteLength(body));
+                    postcss([autoprefixer.apply(null, args)])
+                        .process(body)
+                        .then(function (result) {
+                            res.setHeader('Content-Type', 'text/css');
+                            var upstreamETag = res.getHeader('ETag');
+                            if (upstreamETag) {
+                                res.setHeader('ETag', upstreamETag.replace(/"$/, '-autoprefixer"'));
+                            }
+                            res.setHeader('Content-Length', Buffer.byteLength(result.css));
+                            send(result.css);
+                        })
+                        .catch(function (err) {
+                            send(500, err);
+                        });
+
+                } else {
+                    send(body);
                 }
-                send(body);
             }
         };
     });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express-interceptor": "1.0.1"
   },
   "peerDependencies": {
+    "postcss": "4",
     "autoprefixer": "5"
   },
   "devDependencies": {
@@ -42,6 +43,7 @@
     "messy": "6.2.0",
     "mocha": "1.18.2",
     "passerror": "1.0.1",
+    "postcss": "4.1.11",
     "request": "2.11.4",
     "unexpected": "7.5.0",
     "unexpected-express": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "autoprefixer": "5"
   },
   "devDependencies": {
-    "autoprefixer": "5.0.0",
+    "autoprefixer": "5.2.0",
     "express": "4.12.4",
     "istanbul": "0.3.5",
     "jscs": "1.10.0",


### PR DESCRIPTION
since autoprefixer standalone will be deprecated in the future and
we're getting deprecation warnings when using it without postcss

fix #8