### PR TITLE
add contentType caching by url

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -1,12 +1,35 @@
 var hijackResponse  = require('hijackresponse');
 var autoprefixer = require('autoprefixer');
 var postcss = require('postcss');
+var LRU = require('lru-cache');
 
-module.exports = function () {
+// Hardcoded value can be made optional at a later point - but it will have to
+// work for now, as it would require a breaking change...
+var lruMaxItems = 100;
+
+module.exports = function (options) {
     var args = Array.prototype.slice.call(arguments);
+    var contentTypeCache = new LRU(lruMaxItems);
+    if (options && options._cacheDump) {
+        contentTypeCache.load(options._cacheDump);
+    }
 
     return function (req, res, next) {
         var fileType = (req.originalUrl.match(/\.(le|c)ss$/) || []).shift();
+        var cachedContentType = contentTypeCache.get(req.originalUrl);
+
+        // Attempt to load the content type for this URL from the cache. If we
+        // have the content-type we can determine up front if we need to do any
+        // autoprefixing.
+        // This works under the assumption that it is unlikely that a content
+        // type will change without the file name changing too.
+        // TLDR: If not either the fileType or cachedContentType matches, don't
+        // bother trying to autoprefix.
+        if (!(!!fileType || (cachedContentType && /text\/css/.test(cachedContentType)))) {
+            return next();
+        }
+
+
         // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-autoprefixer":
         var ifNoneMatch = req.headers['if-none-match'];
         if (ifNoneMatch) {
@@ -30,7 +53,10 @@ module.exports = function () {
                 return next(err);
             }
 
-            if (!(!!fileType || /text\/css/.test(res.getHeader('Content-Type')))) {
+            var contentType = res.getHeader('Content-Type');
+            contentTypeCache.set(req.originalUrl, contentType);
+
+            if (!(!!fileType || /text\/css/.test(contentType))) {
                 return res.unhijack();
             }
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "autoprefixer": "^5.0.0",
     "hijackresponse": "1.0.3",
+    "lru-cache": "4.0.0",
     "postcss": "^4.0.0"
   },
   "peerDependencies": {
@@ -37,6 +38,7 @@
     "postcss": "^4.0.0"
   },
   "devDependencies": {
+    "compression": "1.6.1",
     "express": "4.13.4",
     "istanbul": "0.4.2",
     "jscs": "2.10.1",


### PR DESCRIPTION
Attempt to load the content type for the current URL from cache.
If we have the content-type we can determine up front if we need
to do any autoprefixing, and not need to hijack the response.

Solving the problem as described in issue #12

@papandreou can I trouble you for a quick review?