### PR TITLE
Support for urls with querystrings

### DIFF
--- a/lib/autoprefixer.js
+++ b/lib/autoprefixer.js
@@ -17,7 +17,7 @@ module.exports = function expressAutoprefixer() {
     const contentTypeCache = new LRU(lruMaxItems);
 
     return (req, res, next) => {
-        const fileType = (req.originalUrl.match(/\.(le|c)ss$/) || []).shift();
+        const fileType = (req.originalUrl.split('?')[0].match(/\.(le|c)ss$/) || []).shift();
         const cachedContentType = contentTypeCache.get(req.originalUrl);
 
         // Attempt to load the content type for this URL from the cache. If we


### PR DESCRIPTION
Live reload will often append a query string (`styles/main.css?v=1509041358639`). This adds support for those type of requests.